### PR TITLE
Add start & end times to detailed hourly forecast

### DIFF
--- a/pynws/const.py
+++ b/pynws/const.py
@@ -67,6 +67,8 @@ API_WEATHER_CODE = {
 class Detail(StrEnum):
     """Detailed forecast value names"""
 
+    START_TIME = "startTime"
+    END_TIME = "endTime"
     TEMPERATURE = "temperature"
     DEWPOINT = "dewpoint"
     MAX_TEMPERATURE = "maxTemperature"

--- a/pynws/forecast.py
+++ b/pynws/forecast.py
@@ -130,8 +130,8 @@ class DetailedForecast:
         for _ in range(hours):
             end_time = start_time + ONE_HOUR
             details = {
-                "startTime": datetime.isoformat(start_time),
-                "endTime": datetime.isoformat(end_time),
+                Detail.START_TIME: datetime.isoformat(start_time),
+                Detail.END_TIME: datetime.isoformat(end_time),
             }
             details.update(self.get_details_for_time(start_time))
             yield details

--- a/pynws/forecast.py
+++ b/pynws/forecast.py
@@ -130,8 +130,8 @@ class DetailedForecast:
         for _ in range(hours):
             end_time = start_time + ONE_HOUR
             details = {
-                Detail.START_TIME: datetime.isoformat(start_time),
-                Detail.END_TIME: datetime.isoformat(end_time),
+                str(Detail.START_TIME): datetime.isoformat(start_time),
+                str(Detail.END_TIME): datetime.isoformat(end_time),
             }
             details.update(self.get_details_for_time(start_time))
             yield details

--- a/pynws/forecast.py
+++ b/pynws/forecast.py
@@ -127,5 +127,12 @@ class DetailedForecast:
             raise TypeError(f"{start_time!r} is not a datetime")
 
         start_time = start_time.replace(minute=0, second=0, microsecond=0)
-        for hour in range(hours):
-            yield self.get_details_for_time(start_time + timedelta(hours=hour))
+        for _ in range(hours):
+            end_time = start_time + ONE_HOUR
+            details = {
+                "startTime": datetime.isoformat(start_time),
+                "endTime": datetime.isoformat(end_time),
+            }
+            details.update(self.get_details_for_time(start_time))
+            yield details
+            start_time = end_time

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -179,6 +179,10 @@ class SimpleNWS(Nws):
         """Update forecast hourly."""
         self._forecast_hourly = await self.get_gridpoints_forecast_hourly()
 
+    async def update_detailed_forecast(self):
+        """Update forecast."""
+        self._detailed_forecast = await self.get_detailed_forecast()
+
     @staticmethod
     def _unique_alert_ids(alerts):
         """Return set of unique alert_ids."""
@@ -299,6 +303,10 @@ class SimpleNWS(Nws):
     def forecast_hourly(self):
         """Return forecast hourly."""
         return self._convert_forecast(self._forecast_hourly, self.filter_forecast)
+
+    @property
+    def detailed_forecast(self):
+        return self._detailed_forecast
 
     @staticmethod
     def _convert_forecast(input_forecast, filter_forecast):

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -131,6 +131,7 @@ class SimpleNWS(Nws):
         self.stations = None
         self._forecast = None
         self._forecast_hourly = None
+        self._detailed_forecast = None
         self._alerts_forecast_zone = []
         self._alerts_county_zone = []
         self._alerts_fire_weather_zone = []

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -307,6 +307,7 @@ class SimpleNWS(Nws):
 
     @property
     def detailed_forecast(self):
+        """Return detailed forecast."""
         return self._detailed_forecast
 
     @staticmethod


### PR DESCRIPTION
Quick enhancement to include startTime and endTime with detailed hourly forecasts. While I was comparing simple hourly forecasts to detailed hourly forecasts, I found that it would be useful to have these. It would be nice to include this before releasing a new version.