### PR TITLE
Convert dew point units to match temperature units

### DIFF
--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -333,10 +333,10 @@ class SimpleNWS(Nws):
                 if now > datetime.fromisoformat(end_time):
                     continue
 
-            temp_unit = forecast_entry.get("temperatureUnit")
-
             if (value := forecast_entry.get("temperature")) is not None:
                 forecast_entry["temperature"] = int(value)
+
+            temp_unit = forecast_entry.get("temperatureUnit")
 
             for key in ("probabilityOfPrecipitation", "dewpoint", "relativeHumidity"):
                 if (

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -341,12 +341,11 @@ class SimpleNWS(Nws):
             for key in ("probabilityOfPrecipitation", "dewpoint", "relativeHumidity"):
                 extracted = SimpleNWS.extract_value(forecast_entry, key)
                 if isinstance(extracted, tuple):
-                    value, unit = extracted
-                    value = float(value)
-                    if unit.endswith("degC") and temp_unit == "F":
-                        value = round(value * 1.8 + 32, 0)
-                    elif unit.endswith("degF") and temp_unit == "C":
-                        value = round((value - 32) / 1.8, 0)
+                    value, value_unit = extracted
+                    if value_unit.endswith("degC") and temp_unit == "F":
+                        value = round(float(value) * 1.8 + 32, 0)
+                    elif value_unit.endswith("degF") and temp_unit == "C":
+                        value = round((float(value) - 32) / 1.8, 0)
                     forecast_entry[key] = int(value)
 
             if forecast_entry.get("icon"):

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -339,17 +339,14 @@ class SimpleNWS(Nws):
             temp_unit = forecast_entry.get("temperatureUnit")
 
             for key in ("probabilityOfPrecipitation", "dewpoint", "relativeHumidity"):
-                if (
-                    extracted := SimpleNWS.extract_value(forecast_entry, key)
-                ) is not None:
-                    if not isinstance(extracted, tuple):
-                        continue
+                extracted = SimpleNWS.extract_value(forecast_entry, key)
+                if isinstance(extracted, tuple):
                     value, unit = extracted
                     value = float(value)
                     if unit.endswith("degC") and temp_unit == "F":
-                        value = round(value * 1.8 + 32.0, 0)
+                        value = round(value * 1.8 + 32, 0)
                     elif unit.endswith("degF") and temp_unit == "C":
-                        value = round((value - 32.0) / 1.8, 0)
+                        value = round((value - 32) / 1.8, 0)
                     forecast_entry[key] = int(value)
 
             if forecast_entry.get("icon"):

--- a/pynws/simple_nws.py
+++ b/pynws/simple_nws.py
@@ -340,9 +340,11 @@ class SimpleNWS(Nws):
 
             for key in ("probabilityOfPrecipitation", "dewpoint", "relativeHumidity"):
                 if (
-                    value_and_unit := SimpleNWS.extract_value(forecast_entry, key)
+                    extracted := SimpleNWS.extract_value(forecast_entry, key)
                 ) is not None:
-                    value, unit = value_and_unit
+                    if not isinstance(extracted, tuple):
+                        continue
+                    value, unit = extracted
                     value = float(value)
                     if unit.endswith("degC") and temp_unit == "F":
                         value = round(value * 1.8 + 32.0, 0)

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -163,7 +163,7 @@ async def test_nws_forecast(aiohttp_client, event_loop, mock_urls):
 
     assert forecast[0]["temperature"] == 41
     assert forecast[0]["probabilityOfPrecipitation"] == 20
-    assert forecast[0]["dewpoint"] == 5
+    assert forecast[0]["dewpoint"] == 41
     assert forecast[0]["relativeHumidity"] == 63
 
     assert forecast[0]["iconWeather"][0][0] == "Thunderstorm (high cloud cover)"
@@ -200,7 +200,7 @@ async def test_nws_forecast_hourly(aiohttp_client, event_loop, mock_urls):
 
     assert forecast[0]["temperature"] == 78
     assert forecast[0]["probabilityOfPrecipitation"] == 20
-    assert forecast[0]["dewpoint"] == 5
+    assert forecast[0]["dewpoint"] == 41
     assert forecast[0]["relativeHumidity"] == 63
 
 


### PR DESCRIPTION
I noticed that the dew point units don't match the temperature:
```
"dewpoint": {
    "unitCode": "wmoUnit:degC",
    "value": 22.222222222222221
},
```

Ideally, the pynws API would use Celsius for all response values. But some of the NWS responses contain values in strings such as: `Showers and thunderstorms likely. Mostly sunny. High near 98, with temperatures falling to around 95 in the afternoon. Heat index values as high as 106. Southwest wind 5 to 10 mph. Chance of precipitation is 60%. New rainfall amounts less than a tenth of an inch possible.`

So making all degree units in a forecast response match the temperature seems like the least-bad approach.