### PR TITLE
Remove deprecated use of event_loop in tests

### DIFF
--- a/tests/test_nws.py
+++ b/tests/test_nws.py
@@ -14,7 +14,7 @@ USERID = "test_user"
 ZONE = "test_zone"
 
 
-async def test_nws_gridpoints_stations(aiohttp_client, event_loop, mock_urls):
+async def test_nws_gridpoints_stations(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -24,7 +24,7 @@ async def test_nws_gridpoints_stations(aiohttp_client, event_loop, mock_urls):
     assert isinstance(stations, list)
 
 
-async def test_nws_points(aiohttp_client, event_loop, mock_urls):
+async def test_nws_points(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -39,7 +39,7 @@ async def test_nws_points(aiohttp_client, event_loop, mock_urls):
     assert nws.fire_weather_zone
 
 
-async def test_nws_stations_observations(aiohttp_client, event_loop, mock_urls):
+async def test_nws_stations_observations(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -52,7 +52,7 @@ async def test_nws_stations_observations(aiohttp_client, event_loop, mock_urls):
     assert isinstance(observations, list)
 
 
-async def test_nws_stations_observations_latest(aiohttp_client, event_loop, mock_urls):
+async def test_nws_stations_observations_latest(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -65,7 +65,7 @@ async def test_nws_stations_observations_latest(aiohttp_client, event_loop, mock
     assert isinstance(observation, dict)
 
 
-async def test_nws_detailed_forecast(aiohttp_client, event_loop, mock_urls):
+async def test_nws_detailed_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -106,7 +106,7 @@ async def test_nws_detailed_forecast(aiohttp_client, event_loop, mock_urls):
         assert Detail.TEMPERATURE in details
 
 
-async def test_nws_gridpoints_forecast(aiohttp_client, event_loop, mock_urls):
+async def test_nws_gridpoints_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -124,7 +124,7 @@ async def test_nws_gridpoints_forecast(aiohttp_client, event_loop, mock_urls):
     assert values["windSpeed"] == "10 mph"
 
 
-async def test_nws_gridpoints_forecast_hourly(aiohttp_client, event_loop, mock_urls):
+async def test_nws_gridpoints_forecast_hourly(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -142,7 +142,7 @@ async def test_nws_gridpoints_forecast_hourly(aiohttp_client, event_loop, mock_u
     assert values["windSpeed"] == "0 mph"
 
 
-async def test_nws_alerts_active_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_active_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -152,7 +152,7 @@ async def test_nws_alerts_active_zone(aiohttp_client, event_loop, mock_urls):
     assert isinstance(alerts, list)
 
 
-async def test_nws_alerts_forecast_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_forecast_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -162,7 +162,7 @@ async def test_nws_alerts_forecast_zone(aiohttp_client, event_loop, mock_urls):
     assert isinstance(alerts, list)
 
 
-async def test_nws_alerts_county_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_county_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)
@@ -172,7 +172,7 @@ async def test_nws_alerts_county_zone(aiohttp_client, event_loop, mock_urls):
     assert isinstance(alerts, list)
 
 
-async def test_nws_alerts_fire_weather_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_fire_weather_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = Nws(client, USERID, LATLON)

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -14,19 +14,19 @@ Y = 0
 ZONE = "test"
 
 
-async def test_gridpoints_stations(aiohttp_client, event_loop, mock_urls):
+async def test_gridpoints_stations(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_gridpoints_stations(WFO, X, Y, client, USERID)
 
 
-async def test_points(aiohttp_client, event_loop, mock_urls):
+async def test_points(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_points(*LATLON, client, USERID)
 
 
-async def test_stations_observations(aiohttp_client, event_loop, mock_urls):
+async def test_stations_observations(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_stations_observations(STATION, client, USERID)
@@ -36,9 +36,7 @@ async def test_stations_observations(aiohttp_client, event_loop, mock_urls):
     )
 
 
-async def test_stations_observations_start_datetime(
-    aiohttp_client, event_loop, mock_urls
-):
+async def test_stations_observations_start_datetime(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     with pytest.raises(
@@ -52,25 +50,25 @@ async def test_stations_observations_start_datetime(
         )
 
 
-async def test_detailed_forecast(aiohttp_client, event_loop, mock_urls):
+async def test_detailed_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_detailed_forecast(WFO, X, Y, client, USERID)
 
 
-async def test_gridpoints_forecast(aiohttp_client, event_loop, mock_urls):
+async def test_gridpoints_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_gridpoints_forecast(WFO, X, Y, client, USERID)
 
 
-async def test_gridpoints_forecast_hourly(aiohttp_client, event_loop, mock_urls):
+async def test_gridpoints_forecast_hourly(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_gridpoints_forecast_hourly(WFO, X, Y, client, USERID)
 
 
-async def test_alerts_active_zone(aiohttp_client, event_loop, mock_urls):
+async def test_alerts_active_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     await raw_data.raw_alerts_active_zone(ZONE, client, USERID)

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -10,7 +10,7 @@ USERID = "test_user"
 ZONE = "test_zone"
 
 
-async def test_nws_set_station(aiohttp_client, event_loop, mock_urls):
+async def test_nws_set_station(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -19,7 +19,7 @@ async def test_nws_set_station(aiohttp_client, event_loop, mock_urls):
     assert nws.stations == [STATION]
 
 
-async def test_nws_set_station_none(aiohttp_client, event_loop, mock_urls):
+async def test_nws_set_station_none(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -38,7 +38,7 @@ async def test_nws_set_station_none(aiohttp_client, event_loop, mock_urls):
         "stations_observations_multiple_unsorted.json",
     ],
 )
-async def test_nws_observation(aiohttp_client, event_loop, mock_urls, observation_json):
+async def test_nws_observation(aiohttp_client, mock_urls, observation_json):
     app = setup_app(stations_observations=observation_json)
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -61,7 +61,7 @@ async def test_nws_observation(aiohttp_client, event_loop, mock_urls, observatio
     assert observation["iconWeather"][0][1] is None
 
 
-async def test_nws_observation_units(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_units(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_alternate_units.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -74,7 +74,7 @@ async def test_nws_observation_units(aiohttp_client, event_loop, mock_urls):
     assert observation["windGust"] == 10
 
 
-async def test_nws_observation_metar(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_metar(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_metar.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -92,7 +92,7 @@ async def test_nws_observation_metar(aiohttp_client, event_loop, mock_urls):
     assert observation["windGust"] is None
 
 
-async def test_nws_observation_metar_noparse(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_metar_noparse(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_metar_noparse.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -102,7 +102,7 @@ async def test_nws_observation_metar_noparse(aiohttp_client, event_loop, mock_ur
     assert observation["temperature"] is None
 
 
-async def test_nws_observation_empty(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_empty(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -122,7 +122,7 @@ async def test_nws_observation_empty(aiohttp_client, event_loop, mock_urls):
     assert observation["iconWeather"] is None
 
 
-async def test_nws_observation_noprop(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_noprop(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_noprop.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -133,7 +133,7 @@ async def test_nws_observation_noprop(aiohttp_client, event_loop, mock_urls):
     assert observation is None
 
 
-async def test_nws_observation_missing_value(aiohttp_client, event_loop, mock_urls):
+async def test_nws_observation_missing_value(aiohttp_client, mock_urls):
     app = setup_app(stations_observations="stations_observations_missing_value.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -154,7 +154,7 @@ async def test_nws_observation_missing_value(aiohttp_client, event_loop, mock_ur
 
 
 @freeze_time("2019-10-13T14:30:00-04:00")
-async def test_nws_forecast(aiohttp_client, event_loop, mock_urls):
+async def test_nws_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -178,7 +178,7 @@ async def test_nws_forecast(aiohttp_client, event_loop, mock_urls):
 
 
 @freeze_time("2019-10-14T21:30:00-04:00")
-async def test_nws_forecast_discard_stale(aiohttp_client, event_loop, mock_urls):
+async def test_nws_forecast_discard_stale(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client, filter_forecast=True)
@@ -194,7 +194,7 @@ async def test_nws_forecast_discard_stale(aiohttp_client, event_loop, mock_urls)
 
 
 @freeze_time("2019-10-14T20:30:00-04:00")
-async def test_nws_forecast_hourly(aiohttp_client, event_loop, mock_urls):
+async def test_nws_forecast_hourly(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -208,7 +208,7 @@ async def test_nws_forecast_hourly(aiohttp_client, event_loop, mock_urls):
 
 
 @freeze_time("2019-10-13T14:30:00-04:00")
-async def test_nws_forecast_strings(aiohttp_client, event_loop, mock_urls):
+async def test_nws_forecast_strings(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast="gridpoints_forecast_strings.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -224,7 +224,7 @@ async def test_nws_forecast_strings(aiohttp_client, event_loop, mock_urls):
 
 
 @freeze_time("2019-10-13T14:30:00-04:00")
-async def test_nws_forecast_empty(aiohttp_client, event_loop, mock_urls):
+async def test_nws_forecast_empty(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast="gridpoints_forecast_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -234,7 +234,7 @@ async def test_nws_forecast_empty(aiohttp_client, event_loop, mock_urls):
     assert forecast == []
 
 
-async def test_nws_alerts_forecast_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_forecast_zone(aiohttp_client, mock_urls):
     app = setup_app(
         alerts_active_zone=["alerts_active_zone.json", "alerts_active_zone_second.json"]
     )
@@ -255,7 +255,7 @@ async def test_nws_alerts_forecast_zone(aiohttp_client, event_loop, mock_urls):
     assert len(alerts) == 2
 
 
-async def test_nws_alerts_county_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_county_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -264,7 +264,7 @@ async def test_nws_alerts_county_zone(aiohttp_client, event_loop, mock_urls):
     assert alerts
 
 
-async def test_nws_alerts_fire_weather_zone(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_fire_weather_zone(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -273,7 +273,7 @@ async def test_nws_alerts_fire_weather_zone(aiohttp_client, event_loop, mock_url
     assert alerts
 
 
-async def test_nws_alerts_all_zones(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_all_zones(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -286,9 +286,7 @@ async def test_nws_alerts_all_zones(aiohttp_client, event_loop, mock_urls):
     assert len(alerts) == 1
 
 
-async def test_nws_alerts_all_zones_after_forecast(
-    aiohttp_client, event_loop, mock_urls
-):
+async def test_nws_alerts_all_zones_after_forecast(aiohttp_client, mock_urls):
     app = setup_app()
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
@@ -302,7 +300,7 @@ async def test_nws_alerts_all_zones_after_forecast(
     assert len(alerts) == 1
 
 
-async def test_nws_alerts_all_zones_second_alert(aiohttp_client, event_loop, mock_urls):
+async def test_nws_alerts_all_zones_second_alert(aiohttp_client, mock_urls):
     app = setup_app(
         alerts_active_zone=["alerts_active_zone.json", "alerts_active_zone_second.json"]
     )


### PR DESCRIPTION
pytest-asyncio "auto" mode does this automatically, but the explicit use of `event_loop` wasn't removed.