### PR TITLE
Fix utcnow deprecation

### DIFF
--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -44,12 +44,11 @@ async def test_stations_observations_start_datetime(aiohttp_client, mock_urls):
     ):
         await raw_data.raw_stations_observations(STATION, client, USERID, start="1PM")
     with pytest.raises(ValueError, match="start parameter must be timezone aware"):
-        # utcnow is confusingly returns naive
         await raw_data.raw_stations_observations(
             STATION,
             client,
             USERID,
-            start=datetime.utcnow(),  # noqa: DTZ003
+            start=datetime.now(),
         )
 
 


### PR DESCRIPTION
The usage of `utcnow` was correct in that it was intended to be `naive` for the test.  It is deprecated in Python 3.12, so we should use `now` instead.  See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow.

The ruff lint was useful here!