### PR TITLE
Use ruff for vscode linting and fix failed postcreatecommand.sh script 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,12 @@
 {
     "name": "Python 3",
     "image": "mcr.microsoft.com/vscode/devcontainers/python:3.12-bullseye",
-    "postCreateCommand": "./.devcontainer/postcreatecommand.sh"
+    "postCreateCommand": "./.devcontainer/postcreatecommand.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff"
+            ]
+        }
+    }
 }

--- a/.devcontainer/postcreatecommand.sh
+++ b/.devcontainer/postcreatecommand.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+git config --global --add safe.directory "$PWD"
+
 python -m pip install -e .
 python -m pip install -r requirements-test.txt
 python -m pip install pre-commit


### PR DESCRIPTION
Use ruff for vscode linting
Fix failed `pre-commit install` in postcreatecommand.sh script (Windows only?)