### PR TITLE
Refactor 'retry' unit tests

### DIFF
--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -355,7 +355,7 @@ async def test_nws_alerts_all_zones_second_alert(aiohttp_client, mock_urls):
     assert len(alerts) == 2
 
 
-async def test_retries(aiohttp_client, mock_urls):
+async def test_retry_5xx(aiohttp_client, mock_urls):
     with patch("pynws.simple_nws._is_500_error") as err_mock:
         # retry all exceptions
         err_mock.return_value = True
@@ -368,31 +368,36 @@ async def test_retries(aiohttp_client, mock_urls):
         mock_update = AsyncMock()
         mock_update.side_effect = [ValueError, None]
 
-        async def mock_wrap(*args, **kwargs):
-            return await mock_update(*args, **kwargs)
-
-        await call_with_retry(mock_wrap, 0, 5)
+        await call_with_retry(mock_update, 0, 5)
 
         assert mock_update.call_count == 2
 
+
+async def test_retry_with_args():
     mock_update = AsyncMock()
 
-    async def mock_wrap(*args, **kwargs):
-        return await mock_update(*args, **kwargs)
-
-    await call_with_retry(mock_wrap, 0, 5, "", test=None)
+    await call_with_retry(mock_update, 0, 5, "", test=None)
 
     mock_update.assert_called_once_with("", test=None)
 
+
+async def test_retry_invalid_args():
+    mock_update = AsyncMock()
+
     # positional only args
     with pytest.raises(TypeError):
-        call_with_retry(mock_wrap, interval=0, stop=5)
+        # 'interval' and 'stop' will be included in '**kwargs' since positional-only
+        # parameters with these names already exist
+        await call_with_retry(mock_update, interval=0, stop=5)
 
+    assert mock_update.call_count == 0
+
+
+async def test_retries_runtime_error():
     mock_update = AsyncMock()
     mock_update.side_effect = [RuntimeError, None]
 
-    async def mock_wrap(*args, **kwargs):
-        return await mock_update(*args, **kwargs)
-
     with pytest.raises(RuntimeError):
-        await call_with_retry(mock_wrap, 0, 5)
+        await call_with_retry(mock_update, 0, 5)
+
+    assert mock_update.call_count == 1


### PR DESCRIPTION
I broke up the simple_nws retry tests into separate tests.
Removed 'mock_wrap' for Python 3.10+
Added additional assertions