### PR TITLE
Retry with no data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/pynws/__init__.py
+++ b/src/pynws/__init__.py
@@ -4,13 +4,14 @@ asynchronously and organizing the data in an easier to use manner
 """
 
 from .forecast import DetailedForecast
-from .nws import Nws, NwsError
+from .nws import Nws, NwsError, NwsNoDataError
 from .simple_nws import SimpleNWS, call_with_retry
 
 __all__ = [
     "DetailedForecast",
     "Nws",
     "NwsError",
+    "NwsNoDataError",
     "SimpleNWS",
     "call_with_retry",
 ]

--- a/src/pynws/nws.py
+++ b/src/pynws/nws.py
@@ -28,6 +28,10 @@ class NwsError(Exception):
         self.message = message
 
 
+class NwsNoDataError(NwsError):
+    """No data was returned."""
+
+
 class Nws:
     """Class to more easily get data for one location."""
 

--- a/src/pynws/simple_nws.py
+++ b/src/pynws/simple_nws.py
@@ -70,7 +70,7 @@ def _setup_retry_func(
     stop: Union[float, timedelta],
     *,
     retry_no_data=False,
-) -> Callable[[Any, Any], Awaitable[Any]]:
+) -> Callable[..., Awaitable[Any]]:
     from tenacity import retry, retry_if_exception, stop_after_delay, wait_fixed
 
     retry_func = _nws_retry_func(retry_no_data=retry_no_data)

--- a/src/pynws/simple_nws.py
+++ b/src/pynws/simple_nws.py
@@ -89,7 +89,7 @@ async def call_with_retry(
     stop: Union[float, timedelta],
     /,
     *args,
-    retry_no_data=True,
+    retry_no_data=False,
     **kwargs,
 ) -> Callable[[Any, Any], Awaitable[Any]]:
     """Call an update function with retries.
@@ -110,7 +110,7 @@ async def call_with_retry(
         Keyword args to pass to func.
     """
     retried_func = _setup_retry_func(func, interval, stop, retry_no_data=retry_no_data)
-    return await retried_func(*args, **kwargs)
+    return await retried_func(*args, raise_no_data=retry_no_data, **kwargs)
 
 
 class MetarParam(NamedTuple):

--- a/src/pynws/simple_nws.py
+++ b/src/pynws/simple_nws.py
@@ -52,9 +52,23 @@ WIND_DIRECTIONS: Final = [
 WIND: Final = {name: idx * 360 / 16 for idx, name in enumerate(WIND_DIRECTIONS)}
 
 
-def _nws_retry_func(retry_no_data):
+def _nws_retry_func(retry_no_data: bool):
+    """
+    Return function used for tenacity.retry.
+
+    Retry if:
+        - if error is ClientResponseError and has a 5xx status.
+        - if error is NwsNoDataError, the behavior is determined by retry_no_data
+
+    Parameters
+    ----------
+    retry_no_data : bool
+        Whether to retry when `NwsNoDataError` is raised.
+
+    """
+
     def _retry(error: BaseException) -> bool:
-        """Return True if error is ClientResponseError and has a 5xx status."""
+        """Whether to retry based on execptions."""
         if isinstance(error, ClientResponseError) and error.status >= 500:
             return True
         if retry_no_data and isinstance(error, NwsNoDataError):

--- a/src/pynws/simple_nws.py
+++ b/src/pynws/simple_nws.py
@@ -247,16 +247,33 @@ class SimpleNWS(Nws):
         elif raise_no_data:
             raise NwsNoDataError("Observation received with no data.")
 
-    async def update_forecast(self: SimpleNWS) -> None:
+    async def update_forecast(self: SimpleNWS, *, raise_no_data: bool = False) -> None:
         """Update forecast."""
         self._forecast = await self.get_gridpoints_forecast()
+        if not self.forecast and raise_no_data:
+            raise NwsNoDataError("Forecast received with no data.")
 
-    async def update_forecast_hourly(self: SimpleNWS) -> None:
+    async def update_forecast_hourly(
+        self: SimpleNWS, *, raise_no_data: bool = False
+    ) -> None:
         """Update forecast hourly."""
         self._forecast_hourly = await self.get_gridpoints_forecast_hourly()
+        if not self.forecast_hourly and raise_no_data:
+            raise NwsNoDataError("Forecast hourly received with no data.")
 
-    async def update_detailed_forecast(self: SimpleNWS) -> None:
-        """Update forecast."""
+    async def update_detailed_forecast(
+        self: SimpleNWS, *, raise_no_data: bool = False
+    ) -> None:
+        """Update forecast.
+
+        Note:
+        `raise_no_data`currently can only be set to `False`.
+        """
+        if raise_no_data:
+            raise NotImplementedError(
+                "raise_no_data=True not implemented for update_detailed_forecast"
+            )
+
         self._detailed_forecast = await self.get_detailed_forecast()
 
     @staticmethod
@@ -273,22 +290,52 @@ class SimpleNWS(Nws):
         current_alert_ids = self._unique_alert_ids(current_alerts)
         return [alert for alert in alerts if alert[ALERT_ID] not in current_alert_ids]
 
-    async def update_alerts_forecast_zone(self: SimpleNWS) -> List[Dict[str, Any]]:
-        """Update alerts zone."""
+    async def update_alerts_forecast_zone(
+        self: SimpleNWS, *, raise_no_data: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Update alerts zone.
+
+        Note:
+        `raise_no_data`currently can only be set to `False`.
+        """
+        if raise_no_data:
+            raise NotImplementedError(
+                "raise_no_data=True not implemented for update_alerts_forecast_zone"
+            )
         alerts = await self.get_alerts_forecast_zone()
         new_alerts = self._new_alerts(alerts, self._alerts_forecast_zone)
         self._alerts_forecast_zone = alerts
         return new_alerts
 
-    async def update_alerts_county_zone(self: SimpleNWS) -> List[Dict[str, Any]]:
-        """Update alerts zone."""
+    async def update_alerts_county_zone(
+        self: SimpleNWS, *, raise_no_data: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Update alerts zone.
+
+        Note:
+        `raise_no_data`currently can only be set to `False`.
+        """
+        if raise_no_data:
+            raise NotImplementedError(
+                "raise_no_data=True not implemented for update_alerts_county_zone"
+            )
         alerts = await self.get_alerts_county_zone()
         new_alerts = self._new_alerts(alerts, self._alerts_county_zone)
         self._alerts_county_zone = alerts
         return new_alerts
 
-    async def update_alerts_fire_weather_zone(self: SimpleNWS) -> List[Dict[str, Any]]:
-        """Update alerts zone."""
+    async def update_alerts_fire_weather_zone(
+        self: SimpleNWS, *, raise_no_data: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Update alerts zone.
+
+        Note:
+        `raise_no_data`currently can only be set to `False`.
+        """
+        if raise_no_data:
+            raise NotImplementedError(
+                "raise_no_data=True not implemented for update_alerts_fire_weather_zone"
+            )
         alerts = await self.get_alerts_fire_weather_zone()
         new_alerts = self._new_alerts(alerts, self._alerts_fire_weather_zone)
         self._alerts_fire_weather_zone = alerts

--- a/tests/fixtures/gridpoints_forecast_hourly_empty.json
+++ b/tests/fixtures/gridpoints_forecast_hourly_empty.json
@@ -1,0 +1,92 @@
+{
+    "@context": [
+        "https://raw.githubusercontent.com/geojson/geojson-ld/master/contexts/geojson-base.jsonld",
+        {
+            "wx": "https://api.weather.gov/ontology#",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "unit": "http://codes.wmo.int/common/unit/",
+            "@vocab": "https://api.weather.gov/ontology#"
+        }
+    ],
+    "type": "Feature",
+    "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+            {
+                "type": "Point",
+                "coordinates": [
+                    -84.956046999999998,
+                    29.995017300000001
+                ]
+            },
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -84.968174099999999,
+                            30.007206
+                        ],
+                        [
+                            -84.970116500000003,
+                            29.984511300000001
+                        ],
+                        [
+                            -84.943922400000005,
+                            29.982827500000003
+                        ],
+                        [
+                            -84.941974999999999,
+                            30.005522000000003
+                        ],
+                        [
+                            -84.968174099999999,
+                            30.007206
+                        ]
+                    ]
+                ]
+            }
+        ]
+    },
+    "properties": {
+        "updated": "2019-10-14T23:16:24+00:00",
+        "units": "us",
+        "forecastGenerator": "HourlyForecastGenerator",
+        "generatedAt": "2019-10-15T00:12:54+00:00",
+        "updateTime": "2019-10-14T23:16:24+00:00",
+        "validTimes": "2019-10-14T17:00:00+00:00/P7DT20H",
+        "elevation": {
+            "value": 7.9248000000000003,
+            "unitCode": "unit:m"
+        },
+        "periods": [
+            {
+                "number": null,
+                "name": null,
+                "startTime": null,
+                "endTime": null,
+                "isDaytime": null,
+                "temperature": null,
+                "temperatureUnit": null,
+                "temperatureTrend": null,
+                "probabilityOfPrecipitation": {
+                    "unitCode": null,
+                    "value": null
+                },
+                "dewpoint": {
+                    "unitCode": null,
+                    "value": null
+                },
+                "relativeHumidity": {
+                    "unitCode": null,
+                    "value": null
+                },
+                "windSpeed": null,
+                "windDirection": null,
+                "icon": null,
+                "shortForecast": null,
+                "detailedForecast": null
+            }
+        ]
+    }
+}

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -173,6 +173,9 @@ async def test_nws_observation_noprop(aiohttp_client, mock_urls):
 
     assert observation is None
 
+    with pytest.raises(NwsNoDataError, match="Observation received with no data"):
+        await nws.update_observation(raise_no_data=True)
+
 
 async def test_nws_observation_noprop_w_retry(aiohttp_client, mock_urls):
     app = setup_app(
@@ -295,7 +298,7 @@ async def test_nws_forecast_empty_raise(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast="gridpoints_forecast_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
-    with pytest.raises(NwsNoDataError):
+    with pytest.raises(NwsNoDataError, match="Forecast received with no data"):
         await nws.update_forecast(raise_no_data=True)
 
 
@@ -315,7 +318,7 @@ async def test_nws_forecast_hourly_empty_raise(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast_hourly="gridpoints_forecast_hourly_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
-    with pytest.raises(NwsNoDataError):
+    with pytest.raises(NwsNoDataError, match="Hourly forecast received with no data"):
         await nws.update_forecast_hourly(raise_no_data=True)
 
 

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -318,7 +318,7 @@ async def test_nws_forecast_hourly_empty_raise(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast_hourly="gridpoints_forecast_hourly_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
-    with pytest.raises(NwsNoDataError, match="Hourly forecast received with no data"):
+    with pytest.raises(NwsNoDataError, match="Forecast hourly received with no data"):
         await nws.update_forecast_hourly(raise_no_data=True)
 
 

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -356,10 +356,13 @@ async def test_nws_alerts_all_zones_second_alert(aiohttp_client, mock_urls):
     assert len(alerts) == 2
 
 
-async def test_retry_5xx(aiohttp_client, mock_urls):
-    with patch("pynws.simple_nws._is_500_error") as err_mock:
+async def test_retry(aiohttp_client, mock_urls):
+    with patch("pynws.simple_nws._nws_retry_func") as err_mock:
         # retry all exceptions
-        err_mock.return_value = True
+        def _return_true(error):
+            return True
+
+        err_mock.return_value = _return_true
 
         app = setup_app()
         client = await aiohttp_client(app)

--- a/tests/test_simple_nws.py
+++ b/tests/test_simple_nws.py
@@ -326,16 +326,28 @@ async def test_nws_unimplemented_retry_no_data(aiohttp_client, mock_urls):
     app = setup_app(gridpoints_forecast="gridpoints_forecast_empty.json")
     client = await aiohttp_client(app)
     nws = SimpleNWS(*LATLON, USERID, client)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError,
+        match="raise_no_data=True not implemented for update_detailed_forecast",
+    ):
         await nws.update_detailed_forecast(raise_no_data=True)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError,
+        match="raise_no_data=True not implemented for update_alerts_forecast_zone",
+    ):
         await nws.update_alerts_forecast_zone(raise_no_data=True)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError,
+        match="raise_no_data=True not implemented for update_alerts_county_zone",
+    ):
         await nws.update_alerts_county_zone(raise_no_data=True)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError,
+        match="raise_no_data=True not implemented for update_alerts_fire_weather_zone",
+    ):
         await nws.update_alerts_fire_weather_zone(raise_no_data=True)
 
 


### PR DESCRIPTION
This ~partially~ mostly addresses #194.

This detects no data in observation and forecasts.  Also detects all stale forecasts if the right flag is passed.