### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,9 +14,8 @@ dependencies = [
 description = "Python library to retrieve observations and forecasts from NWS/NOAA"
 readme = {file = "README.md", content-type = "text/markdown"}
 keywords = ["nws", "weather"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Setuptools `v77` added support for PEP 639 license expressions.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files